### PR TITLE
geo2rdr resamp

### DIFF
--- a/src/compass/geo2rdr.py
+++ b/src/compass/geo2rdr.py
@@ -55,18 +55,19 @@ def run(cfg: dict):
         # Get topo layers
         topo_raster = isce3.io.Raster(f'{file_path}/topo.vrt')
 
-        # Get radar grid and orbit for the burst
-        for burst in bursts:
-            rdr_grid = burst.as_isce3_radargrid()
-            orbit = burst.orbit
+        # Get 1st burst and associated radar grid + orbit
+        # geo2rdr does not need polarization
+        burst = bursts[0]
+        rdr_grid = burst.as_isce3_radargrid()
+        orbit = burst.orbit
 
-            # Initialize geo2rdr object
-            geo2rdr_obj = geo2rdr(rdr_grid, orbit, ellipsoid,
-                                  isce3.core.LUT2d(),
-                                  threshold, iters,
-                                  blocksize)
-            # Execute geo2rdr
-            geo2rdr_obj.geo2rdr(topo_raster, output_path)
+        # Initialize geo2rdr object
+        geo2rdr_obj = geo2rdr(rdr_grid, orbit, ellipsoid,
+                              isce3.core.LUT2d(),
+                              threshold, iters,
+                              blocksize)
+        # Execute geo2rdr
+        geo2rdr_obj.geo2rdr(topo_raster, output_path)
 
     dt = time.time() - t_start
     info_channel.log(f"geo2rdr successfully ran in {dt:.3f} seconds")

--- a/src/compass/geo2rdr.py
+++ b/src/compass/geo2rdr.py
@@ -42,11 +42,11 @@ def run(cfg: dict):
         geo2rdr = isce3.geometry.Geo2Rdr
 
     # Get specific geo2rdr parameters from runconfig
-    threshold = cfg.geo2rdr_params.__dict__["threshold"]
-    iters = cfg.geo2rdr_params.__dict__["numiter"]
-    blocksize = cfg.geo2rdr_params.__dict__["lines_per_block"]
+    threshold = cfg.geo2rdr_params.threshold
+    iters = cfg.geo2rdr_params.numiter
+    blocksize = cfg.geo2rdr_params.lines_per_block
 
-    for file_path,bursts in zip(cfg.reference_path, cfg.bursts):
+    for file_path, bursts in zip(cfg.reference_path, cfg.bursts):
         # Create output directory
         output_path = f'{cfg.scratch_path}/' \
                       f'{bursts[0].burst_id}/geo2rdr'

--- a/src/compass/geo2rdr.py
+++ b/src/compass/geo2rdr.py
@@ -32,10 +32,14 @@ def run(cfg: dict):
     ellipsoid = proj.ellipsoid
 
     # Check if user wants to use GPU for processing
+    # Initialize CPU or GPU geo2rdr object
     use_gpu = isce3.core.gpu_check.use_gpu(cfg.gpu_enabled, cfg.gpu_id)
     if use_gpu:
         device = isce3.core.cuda.Device(cfg.gpu_id)
         isce3.cuda.core.set_device(device)
+        geo2rdr = isce3.cuda.geometry.Geo2Rdr
+    else:
+        geo2rdr = isce3.geometry.Geo2Rdr
 
     # Get specific geo2rdr parameters from runconfig
     threshold = cfg.geo2rdr_params.__dict__["threshold"]
@@ -55,12 +59,6 @@ def run(cfg: dict):
         for burst in bursts:
             rdr_grid = burst.as_isce3_radargrid()
             orbit = burst.orbit
-
-            # Initialize CPU or GPU geo2rdr object
-            if use_gpu:
-                geo2rdr = isce3.cuda.geometry.Geo2Rdr
-            else:
-                geo2rdr = isce3.geometry.Geo2Rdr
 
             # Initialize geo2rdr object
             geo2rdr_obj = geo2rdr(rdr_grid, orbit, ellipsoid,

--- a/src/compass/rdr2geo.py
+++ b/src/compass/rdr2geo.py
@@ -26,12 +26,15 @@ def run(cfg):
     proj = isce3.core.make_projection(epsg)
     ellipsoid = proj.ellipsoid
 
-    # check if gpu ok to use
+    # check if gpu ok to use and init CPU or CUDA object accordingly
     use_gpu = isce3.core.gpu_check.use_gpu(cfg.gpu_enabled, cfg.gpu_id)
     if use_gpu:
         # Set the current CUDA device.
         device = isce3.cuda.core.Device(cfg.gpu_id)
         isce3.cuda.core.set_device(device)
+        Rdr2Geo = isce3.cuda.geometry.Rdr2Geo
+    else:
+        Rdr2Geo = isce3.geometry.Rdr2Geo
 
     # save SLC for all bursts
     # run rdr2geo for only once per burst_id
@@ -51,12 +54,6 @@ def run(cfg):
 
         # init grid doppler
         grid_doppler = isce3.core.LUT2d()
-
-        # init CPU or CUDA object accordingly
-        if use_gpu:
-            Rdr2Geo = isce3.cuda.geometry.Rdr2Geo
-        else:
-            Rdr2Geo = isce3.geometry.Rdr2Geo
 
         # init rdr2geo obj
         rdr2geo_obj = Rdr2Geo(

--- a/src/compass/resample_burst.py
+++ b/src/compass/resample_burst.py
@@ -30,7 +30,7 @@ def run(cfg: dict):
     # Instantiate and initialize resample object
     use_gpu = isce3.core.gpu_check.use_gpu(cfg.gpu_enabled, cfg.gpu_id)
     if use_gpu:
-        device = isce3.core.cuda.Device(cfg.gpu_id)
+        device = isce3.cuda.core.Device(cfg.gpu_id)
         isce3.cuda.core.set_device(device)
         resamp = isce3.cuda.image.ResampSlc
     else:
@@ -40,41 +40,53 @@ def run(cfg: dict):
     blocksize = cfg.resample_params.lines_per_block
 
     for bursts in cfg.bursts:
-        # Create output path
-        output_path = f'{cfg.product_path}/{bursts[0].burst_id}'
-        os.makedirs(output_path, exist_ok=True)
+        # Create top output path
+        top_output_path = f'{cfg.product_path}/{bursts[0].burst_id}'
+        os.makedirs(top_output_path, exist_ok=True)
 
         for burst in bursts:
+            # Extract date string and create directory
+            date_str = str(burst.sensing_start.date())
+            burst_output_path = f'{top_output_path}/{date_str}'
+            os.makedirs(burst_output_path, exist_ok=True)
+
+            # Extract polarization
+            pol = burst.polarization
+
             # Get radar grid
             rdr_grid = burst.as_isce3_radargrid()
 
             # Extract azimuth carrier polynomials
             az_poly = burst.get_az_carrier_poly(index_as_coord=True)
 
+            # Init resample SLC object
             resamp_obj = resamp(rdr_grid, burst.doppler.lut2d,
                                 az_poly)
             resamp_obj.lines_per_tile = blocksize
 
             # Get range and azimuth offsets
             offset_path = f'{cfg.scratch_path}/' \
-                          f'{burst.burst_id}/geo2rdr'
+                          f'{burst.burst_id}/{date_str}'
             rg_off_raster = isce3.io.Raster(f'{offset_path}/range.off')
             az_off_raster = isce3.io.Raster(f'{offset_path}/azimuth.off')
 
-            # Extract polarization
-            pol = burst.polarization
-            sec_burst_path = f'{cfg.scratch_path}/{burst.burst_id}/sec_burst_{pol}.slc'
+            # Get original SLC as raster object
+            sec_burst_path = f'{cfg.scratch_path}/{burst.burst_id}_{date_str}_{pol}.slc'
             burst.slc_to_file(sec_burst_path)
-            burst_raster = isce3.io.Raster(sec_burst_path)
-            coreg_burst_path = f'{output_path}/coreg_{burst.burst_id}_{pol}.slc'
-            resamp_burst_raster = isce3.io.Raster(coreg_burst_path,
-                                                  rg_off_raster.width,
-                                                  rg_off_raster.length,
-                                                  rg_off_raster.num_bands,
-                                                  gdal.GDT_CFloat32,
-                                                  'ENVI')
-            resamp_obj.resamp(burst_raster, resamp_burst_raster,
+            original_raster = isce3.io.Raster(sec_burst_path)
+
+            # Prepare resamled SLC as raster object
+            coreg_burst_path = f'{burst_output_path}/{pol}.slc'
+            resampled_raster = isce3.io.Raster(coreg_burst_path,
+                                               rg_off_raster.width,
+                                               rg_off_raster.length,
+                                               rg_off_raster.num_bands,
+                                               gdal.GDT_CFloat32,
+                                               'ENVI')
+
+            resamp_obj.resamp(original_raster, resampled_raster,
                               rg_off_raster, az_off_raster)
+
     dt = time.time() - t_start
     info_channel.log(f"resample burst successfully ran in {dt:.3f} seconds")
 

--- a/src/compass/resample_burst.py
+++ b/src/compass/resample_burst.py
@@ -27,10 +27,14 @@ def run(cfg: dict):
     t_start = time.time()
 
     # Check if user wants to use GPU for processing
+    # Instantiate and initialize resample object
     use_gpu = isce3.core.gpu_check.use_gpu(cfg.gpu_enabled, cfg.gpu_id)
     if use_gpu:
         device = isce3.core.cuda.Device(cfg.gpu_id)
         isce3.cuda.core.set_device(device)
+        resamp = isce3.cuda.image.ResampSlc
+    else:
+        resamp = isce3.image.ResampSlc
 
     # Get common resample parameters
     blocksize = cfg.resample_params.lines_per_block
@@ -46,12 +50,6 @@ def run(cfg: dict):
 
             # Extract azimuth carrier polynomials
             az_poly = burst.get_az_carrier_poly(index_as_coord=True)
-
-            # Instantiate and initialize resample object
-            if use_gpu:
-               resamp = isce3.cuda.image.ResampSlc
-            else:
-               resamp = isce3.image.ResampSlc
 
             resamp_obj = resamp(rdr_grid, burst.doppler.lut2d,
                                 az_poly)

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -12,7 +12,7 @@ from ruamel.yaml import YAML
 from compass.utils import helpers
 from compass.utils.wrap_namespace import wrap_namespace
 from sentinel1_reader.sentinel1_burst_slc import Sentinel1BurstSlc
-from sentinel1_reader.sentinel1_orbit_reader import get_swath_orbit_file_from_list
+from sentinel1_reader.sentinel1_orbit_reader import get_orbit_file_from_list
 from sentinel1_reader.sentinel1_reader import burst_from_zip
 
 
@@ -117,7 +117,7 @@ def load_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
         zip_list = zip(cycle(pols), i_subswaths)
 
         # find orbit file
-        orbit_path = get_swath_orbit_file_from_list(
+        orbit_path = get_orbit_file_from_list(
             safe_file,
             cfg.input_file_group.orbit_file_path)
 

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -138,13 +138,17 @@ def load_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
                 # does burst_id + pol exist?
                 burst_id_pol_exist = False
                 if burst_id in bursts:
-                    if any([True for b in bursts[burst_id] if b.pol == pol]):
+                    if any([True for b in bursts[burst_id]
+                            if b.polarization == pol]):
                         burst_id_pol_exist = True
 
-                # if not rdr2geo/reference, then ok to add more than 1 instance
-                # of burst_id + pol
+                # ok to add logic table
+                # is_ref\id_pol_exist | true  | false
+                # --------------------+-------+-------
+                # true                | false | true
+                # false               | true  | true
                 is_ref = cfg.input_file_group.reference_burst.is_reference
-                ok_to_add = not is_ref and not burst_id_pol_exist
+                ok_to_add = not is_ref or not burst_id_pol_exist
 
                 # add burst if wanted and doesn't already exist
                 if burst_id_wanted and ok_to_add:

--- a/src/compass/utils/schemas/cslc_s1.yaml
+++ b/src/compass/utils/schemas/cslc_s1.yaml
@@ -45,7 +45,7 @@ reference_burst_options:
     is_reference: bool()
     # File path to reference burst to which coregister secondary burst.
     # Only used if the flag is_reference is set to False.
-    file_path: list(str(), min=1, required=False)
+    file_path: str(required=False)
 
 geo2rdr_options:
    # Convergence threshold for rdr2geo algorithm


### PR DESCRIPTION
This PR builds on the original PR

- simplifies/consolidates CPU/GPU if/else blocks
- updates `sentinel1-reader` method calls
- eliminates accounting for polarization in geo2rdr
- rework output directory structure for geo2rdr and resample SLC to account for burst ID + polarization pairs common to bursts from different days
- accounts for bursts with same ID but different dates

TODO:
- ~~test; nothing is tested presently~~